### PR TITLE
fix: allow colons in casbin rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [lib/v0.0.3] - 2025-05-26
+
+### 🐛 Bug Fixes
+
+- allow colons in casbin rule
+
 ## [lib/v0.0.2] - 2025-05-26
 
 ### 🐛 Bug Fixes

--- a/lib/domains/adminroles.go
+++ b/lib/domains/adminroles.go
@@ -497,6 +497,6 @@ func ValidateRoleAndPermissions(roleID string, permissions []*AdminRolePermissio
 }
 
 func containsInvalidCharacters(param string) bool {
-	r := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	r := regexp.MustCompile(`^[a-zA-Z0-9_:-]+$`)
 	return !r.MatchString(param)
 }

--- a/lib/domains/adminroles_test.go
+++ b/lib/domains/adminroles_test.go
@@ -134,11 +134,11 @@ func TestValidateRoleAndPermissions(t *testing.T) {
 			Err: errors.Initialize(http.StatusBadRequest, "Permission in policy can only contain alphanumeric characters, hyphens, and underscores."),
 		},
 		{
-			Title:  "Role id with hyphen and underscore.",
+			Title:  "Role id with hyphen and underscore and colon.",
 			RoleId: "role-00011_",
 			Permissions: []*AdminRolePermission{
 				{
-					ResourceID: "resource-00011_",
+					ResourceID: "resource:-00011_",
 					Permission: "read",
 				},
 			},


### PR DESCRIPTION
## Overview

Allow colons in casbin rule
