### PR TITLE
ci: add permissions block to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+# NOTE: grant GITHUB_TOKEN only the minimum required permissions
+# - contents: write → required for git tag push / gh release create
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Overview

Explicitly grant the minimum required permissions so the workflow keeps working even after GITHUB_TOKEN's default permissions are switched to read-only in the future.

- contents: write (required for git tag push / gh release create)

## References

N/A

